### PR TITLE
Reconcile template.html with its counterpart from upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ framework_dir := bootstrap-4.4.1-dist
 
 # Arguments to Pandoc; these are reasonable defaults
 pandoc_args += --template style/template.html
+pandoc_args += -M document-css=false
 pandoc_args += --css css/$(framework).css
 pandoc_args += --css css/mods.css
 pandoc_args += -t html5 -s --mathjax --toc

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ watch-pandoc:
 watch-browser-sync:
 	browser-sync start -w -s docs
 
-docs/index.html: lit/index.md style/template.html style/styles.html Makefile
+docs/index.html: lit/index.md style/template.html style/scripts.html style/styles.html Makefile
 	@mkdir -p docs
 	pandoc $(pandoc_args) $< -o $@
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ watch-pandoc:
 watch-browser-sync:
 	browser-sync start -w -s docs
 
-docs/index.html: lit/index.md style/template.html Makefile
+docs/index.html: lit/index.md style/template.html style/styles.html Makefile
 	@mkdir -p docs
 	pandoc $(pandoc_args) $< -o $@
 

--- a/{{cookiecutter.project_slug}}/style/scripts.html
+++ b/{{cookiecutter.project_slug}}/style/scripts.html
@@ -1,0 +1,12 @@
+$if(math)$
+  $math$
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+$endif$
+<!-- <script data-main="scripts/main" src="js/require.js"></script> -->
+  <!-- Load React. -->
+  <!-- Note: when deploying, replace "development.js" with "production.min.js". -->
+<!--  <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script> -->
+  <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
+  <script type="text/javascript" src="js/bootstrap.js"></script>

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -1,6 +1,6 @@
 $if(document-css)$
 html {
-  line-height: $if(linestretch)$$linestretch$$else$1.7$endif$;
+  line-height: $if(linestretch)$$linestretch$$else$1.5$endif$;
   font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;
   font-size: $if(fontsize)$$fontsize$$else$20px$endif$;
   color: $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
@@ -8,7 +8,7 @@ html {
 }
 body {
   margin: 0 auto;
-  max-width: 40em;
+  max-width: 36em;
   padding-left: $if(margin-left)$$margin-left$$else$50px$endif$;
   padding-right: $if(margin-right)$$margin-right$$else$50px$endif$;
   padding-top: $if(margin-top)$$margin-top$$else$50px$endif$;
@@ -28,6 +28,7 @@ body {
   body {
     background-color: transparent;
     color: black;
+    font-size: 12pt;
   }
   p, h2, h3 {
     orphans: 3;
@@ -38,7 +39,7 @@ body {
   }
 }
 p {
-  margin-top: 1.7em;
+  margin: 1em 0;
 }
 a {
   color: $if(linkcolor)$$linkcolor$$else$#1a1a1a$endif$;
@@ -50,59 +51,90 @@ img {
   max-width: 100%;
 }
 h1, h2, h3, h4, h5, h6 {
-  margin-top: 1.7em;
+  margin-top: 1.4em;
+}
+h5, h6 {
+  font-size: 1em;
+  font-style: italic;
+}
+h6 {
+  font-weight: normal;
 }
 ol, ul {
   padding-left: 1.7em;
-  margin-top: 1.7em;
+  margin-top: 1em;
 }
 li > ol, li > ul {
   margin-top: 0;
 }
 blockquote {
-  margin: 1.7em 0 1.7em 1.7em;
+  margin: 1em 0 1em 1.7em;
   padding-left: 1em;
   border-left: 2px solid #e6e6e6;
-  font-style: italic;
+  color: #606060;
 }
 code {
   font-family: $if(monofont)$$monofont$$else$Menlo, Monaco, 'Lucida Console', Consolas, monospace$endif$;
-  background-color: #f0f0f0;
+$if(monobackgroundcolor)$
+  background-color: $monobackgroundcolor$;
+  padding: .2em .4em;
+$endif$
   font-size: 85%;
   margin: 0;
-  padding: .2em .4em;
 }
 pre {
-  line-height: 1.5em;
+  margin: 1em 0;
+$if(monobackgroundcolor)$
+  background-color: $monobackgroundcolor$;
   padding: 1em;
-  background-color: #f0f0f0;
+$endif$
   overflow: auto;
 }
 pre code {
   padding: 0;
   overflow: visible;
 }
+.sourceCode {
+ background-color: transparent;
+ overflow: visible;
+}
 hr {
   background-color: #1a1a1a;
   border: none;
   height: 1px;
-  margin-top: 1.7em;
+  margin: 1em 0;
 }
 table {
+  margin: 1em 0;
   border-collapse: collapse;
   width: 100%;
   overflow-x: auto;
   display: block;
+  font-variant-numeric: lining-nums tabular-nums;
 }
-th, td {
-  border-bottom: 1px solid lightgray;
-  padding: 1em 3em 1em 0;
+table caption {
+  margin-bottom: 0.75em;
+}
+tbody {
+  margin-top: 0.5em;
+  border-top: 1px solid $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
+  border-bottom: 1px solid $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
+}
+th {
+  border-top: 1px solid $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
+  padding: 0.25em 0.5em 0.25em 0.5em;
+}
+td {
+  padding: 0.125em 0.5em 0.25em 0.5em;
 }
 header {
-  margin-bottom: 6em;
+  margin-bottom: 4em;
   text-align: center;
 }
-nav a:not(:hover) {
+#TOC li {
+  list-style: none;
+}
+#TOC a:not(:hover) {
   text-decoration: none;
 }
 $endif$

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -1,3 +1,111 @@
+$if(document-css)$
+html {
+  line-height: $if(linestretch)$$linestretch$$else$1.7$endif$;
+  font-family: $if(mainfont)$$mainfont$$else$Georgia, serif$endif$;
+  font-size: $if(fontsize)$$fontsize$$else$20px$endif$;
+  color: $if(fontcolor)$$fontcolor$$else$#1a1a1a$endif$;
+  background-color: $if(backgroundcolor)$$backgroundcolor$$else$#fdfdfd$endif$;
+}
+body {
+  margin: 0 auto;
+  max-width: 40em;
+  padding-left: $if(margin-left)$$margin-left$$else$50px$endif$;
+  padding-right: $if(margin-right)$$margin-right$$else$50px$endif$;
+  padding-top: $if(margin-top)$$margin-top$$else$50px$endif$;
+  padding-bottom: $if(margin-bottom)$$margin-bottom$$else$50px$endif$;
+  hyphens: auto;
+  word-wrap: break-word;
+  text-rendering: optimizeLegibility;
+  font-kerning: normal;
+}
+@media (max-width: 600px) {
+  body {
+    font-size: 0.9em;
+    padding: 1em;
+  }
+}
+@media print {
+  body {
+    background-color: transparent;
+    color: black;
+  }
+  p, h2, h3 {
+    orphans: 3;
+    widows: 3;
+  }
+  h2, h3, h4 {
+    page-break-after: avoid;
+  }
+}
+p {
+  margin-top: 1.7em;
+}
+a {
+  color: $if(linkcolor)$$linkcolor$$else$#1a1a1a$endif$;
+}
+a:visited {
+  color: $if(linkcolor)$$linkcolor$$else$#1a1a1a$endif$;
+}
+img {
+  max-width: 100%;
+}
+h1, h2, h3, h4, h5, h6 {
+  margin-top: 1.7em;
+}
+ol, ul {
+  padding-left: 1.7em;
+  margin-top: 1.7em;
+}
+li > ol, li > ul {
+  margin-top: 0;
+}
+blockquote {
+  margin: 1.7em 0 1.7em 1.7em;
+  padding-left: 1em;
+  border-left: 2px solid #e6e6e6;
+  font-style: italic;
+}
+code {
+  font-family: $if(monofont)$$monofont$$else$Menlo, Monaco, 'Lucida Console', Consolas, monospace$endif$;
+  background-color: #f0f0f0;
+  font-size: 85%;
+  margin: 0;
+  padding: .2em .4em;
+}
+pre {
+  line-height: 1.5em;
+  padding: 1em;
+  background-color: #f0f0f0;
+  overflow: auto;
+}
+pre code {
+  padding: 0;
+  overflow: visible;
+}
+hr {
+  background-color: #1a1a1a;
+  border: none;
+  height: 1px;
+  margin-top: 1.7em;
+}
+table {
+  border-collapse: collapse;
+  width: 100%;
+  overflow-x: auto;
+  display: block;
+}
+th, td {
+  border-bottom: 1px solid lightgray;
+  padding: 1em 3em 1em 0;
+}
+header {
+  margin-bottom: 6em;
+  text-align: center;
+}
+nav a:not(:hover) {
+  text-decoration: none;
+}
+$endif$
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
 span.underline{text-decoration: underline;}

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -10,3 +10,6 @@ $endif$
 $if(highlighting-css)$
 $highlighting-css$
 $endif$
+$if(displaymath-css)$
+.display.math{display: block; text-align: center; margin: 0.5rem auto;}
+$endif$

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -1,0 +1,11 @@
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+span.underline{text-decoration: underline;}
+div.line-block{white-space: pre-line;}
+div.column{display: inline-block; vertical-align: top; width: 50%;}
+$if(quotes)$
+q { quotes: "“" "”" "‘" "’"; }
+$endif$
+$if(highlighting-css)$
+$highlighting-css$
+$endif$

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -13,3 +13,27 @@ $endif$
 $if(displaymath-css)$
 .display.math{display: block; text-align: center; margin: 0.5rem auto;}
 $endif$
+$if(csl-css)$
+div.csl-bib-body { }
+div.csl-entry {
+  clear: both;
+$if(csl-entry-spacing)$
+  margin-bottom: $csl-entry-spacing$;
+$endif$
+}
+.hanging div.csl-entry {
+  margin-left:2em;
+  text-indent:-2em;
+}
+div.csl-left-margin {
+  min-width:2em;
+  float:left;
+}
+div.csl-right-inline {
+  margin-left:2em;
+  padding-left:1em;
+}
+div.csl-indent {
+  margin-left: 2em;
+}
+$endif$

--- a/{{cookiecutter.project_slug}}/style/styles.html
+++ b/{{cookiecutter.project_slug}}/style/styles.html
@@ -1,8 +1,9 @@
 code{white-space: pre-wrap;}
 span.smallcaps{font-variant: small-caps;}
 span.underline{text-decoration: underline;}
-div.line-block{white-space: pre-line;}
 div.column{display: inline-block; vertical-align: top; width: 50%;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
 $if(quotes)$
 q { quotes: "“" "”" "‘" "’"; }
 $endif$

--- a/{{cookiecutter.project_slug}}/style/template.html
+++ b/{{cookiecutter.project_slug}}/style/template.html
@@ -25,7 +25,6 @@ $for(css)$
 $endfor$
 $if(math)$
   $math$
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 $endif$
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
@@ -33,13 +32,6 @@ $endif$
 $for(header-includes)$
   $header-includes$
 $endfor$
-<!-- <script data-main="scripts/main" src="js/require.js"></script> -->
-  <!-- Load React. -->
-  <!-- Note: when deploying, replace "development.js" with "production.min.js". -->
-<!--  <script src="https://unpkg.com/react@16/umd/react.development.js" crossorigin></script>
-  <script src="https://unpkg.com/react-dom@16/umd/react-dom.development.js" crossorigin></script> -->
-
-
 </head>
 <body class="d-flex flex-column">
 $for(include-before)$
@@ -83,8 +75,6 @@ $endif$
 $for(include-after)$
 $include-after$
 $endfor$
-<script src="https://code.jquery.com/jquery-3.4.1.slim.min.js" integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n" crossorigin="anonymous"></script>
-<script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-  <script type="text/javascript" src="js/bootstrap.js"></script>
+$scripts.html()$
 </body>
 </html>

--- a/{{cookiecutter.project_slug}}/style/template.html
+++ b/{{cookiecutter.project_slug}}/style/template.html
@@ -13,18 +13,22 @@ $endif$
 $if(keywords)$
   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
 $endif$
+$if(description-meta)$
+  <meta name="description" content="$description-meta$" />
+$endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-  <style type="text/css">
+  <style>
       code{white-space: pre-wrap;}
       span.smallcaps{font-variant: small-caps;}
       span.underline{text-decoration: underline;}
+      div.line-block{white-space: pre-line;}
       div.column{display: inline-block; vertical-align: top; width: 50%;}
 $if(quotes)$
       q { quotes: "“" "”" "‘" "’"; }
 $endif$
   </style>
 $if(highlighting-css)$
-  <style type="text/css">
+  <style>
 $highlighting-css$
   </style>
 $endif$
@@ -55,7 +59,7 @@ $include-before$
 $endfor$
 
 $if(toc)$
-<nav id="$idprefix$TOC" class="navbar navbar-dark bg-dark">
+<nav id="$idprefix$TOC" role="doc-toc" class="navbar navbar-dark bg-dark">
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/{{cookiecutter.project_slug}}/style/template.html
+++ b/{{cookiecutter.project_slug}}/style/template.html
@@ -18,20 +18,8 @@ $if(description-meta)$
 $endif$
   <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
   <style>
-      code{white-space: pre-wrap;}
-      span.smallcaps{font-variant: small-caps;}
-      span.underline{text-decoration: underline;}
-      div.line-block{white-space: pre-line;}
-      div.column{display: inline-block; vertical-align: top; width: 50%;}
-$if(quotes)$
-      q { quotes: "“" "”" "‘" "’"; }
-$endif$
+    $styles.html()$
   </style>
-$if(highlighting-css)$
-  <style>
-$highlighting-css$
-  </style>
-$endif$
 $for(css)$
   <link rel="stylesheet" href="$css$" />
 $endfor$

--- a/{{cookiecutter.project_slug}}/style/template.html
+++ b/{{cookiecutter.project_slug}}/style/template.html
@@ -24,8 +24,8 @@ $for(css)$
   <link rel="stylesheet" href="$css$" />
 $endfor$
 $if(math)$
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-<script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
+  $math$
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
 $endif$
   <!--[if lt IE 9]>
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
@@ -45,19 +45,6 @@ $endfor$
 $for(include-before)$
 $include-before$
 $endfor$
-
-$if(toc)$
-<nav id="$idprefix$TOC" role="doc-toc" class="navbar navbar-dark bg-dark">
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
-  </button>
-  <a href="#" class="ml-5 mr-auto navbar-brand">$title$<br><span style="font-size: smaller">$subtitle$ by <i>$author$</i></span></a>
-<div class="collapse navbar-collapse" id="navbarSupportedContent">
-$table-of-contents$
-</div>
-</nav>
-$endif$
-
 <!-- $if(title)$
 <nav class="navbar navbar-dark navbar-expand-md bg-dark mb-4">
 $if(subtitle)$
@@ -71,6 +58,17 @@ $if(date)$
 $endif$
 </nav>
 $endif$ -->
+$if(toc)$
+<nav id="$idprefix$TOC" role="doc-toc" class="navbar navbar-dark bg-dark">
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <a href="#" class="ml-5 mr-auto navbar-brand">$title$<br><span style="font-size: smaller">$subtitle$ by <i>$author$</i></span></a>
+<div class="collapse navbar-collapse" id="navbarSupportedContent">
+$table-of-contents$
+</div>
+</nav>
+$endif$
 
 <main role="main" class="flex-fill"><div class="container my-5">
 $body$


### PR DESCRIPTION
As Pandoc evolved, so did the default html template, whose source can be found [here](https://github.com/jgm/pandoc-templates/blob/master/default.html5).

This PR is a list of fine-grained commits that apply the changes from upstream to the `template.html` file, make it up to date with its counterpart, and make it easier to keep up to date with further changes.

Hopefully it helps newcomers to adopt your cookiecutter, by making it easier to grasp which parts of the code is specific to this project, and which parts are not.

List of commits:
- feat(template.html): Apply changes from upstream
- feat(template.html): Apply changes from upstream (styles.html partial)
- feat(styles.html): Apply changes from upstream
- feat(styles.html): Apply changes from upstream
- feat(styles.html): Apply changes from upstream
- feat(styles.html): Apply changes from upstream (Pandoc 2.11, 2/2)
- feat(styles.html): Apply changes from upstream (Pandoc 2.11.1)
- feat(template.html): Output MathJax script using command-line
- feat(template.html): Add a scripts.html partial
